### PR TITLE
memcpy support, so -Os works

### DIFF
--- a/build/Makefile.FULL
+++ b/build/Makefile.FULL
@@ -16,7 +16,7 @@ IDENT='-DID="Rev 2.1"' -DSUN3 -DCARRERA
 # Now this is in bootrom.lds
 #RELOC=0FEF0000
 
-# -Os requries memcpy
+# -Os requries memcpy (now supplied), smallest (~51 KiB)
 # -O3 produces a binary > 64 KiB
 # -O2 works but is quite close to 64 KiB
 # -O1 works and has some margin (~54 KiB)
@@ -40,6 +40,9 @@ SIZE = m68k-linux-gnu-size
 
 DUMP = m68k-linux-gnu-objdump -d
 
+# memcpy
+MEMCPY_OBJS = memcpy.o
+
 OBJS = romvec.o trap.o mapmem.o reset.o cpu.map.o \
 	diag.o banner.o commands.o idprom.o usecmd.o  \
 	getline.o printf.o busyio.o \
@@ -51,7 +54,8 @@ OBJS = romvec.o trap.o mapmem.o reset.o cpu.map.o \
 	scutils.o space.o st.o \
 	inet.o tftp.o \
 	diagmenus.o machdep.o cmp.o patt.o db.o si.o \
-	version.o
+	version.o \
+	$(MEMCPY_OBJS)
 
 # These are devices we never intend to deal with
 ALT_OBJS = xy.o tm.o xt.o xd.o
@@ -224,6 +228,8 @@ si.o: ../dev/si.c
 rop.o: ../sys/rop.s
 	$(AS) -c $<
 
+memcpy.o: ../sys/memcpy.S
+	$(AS) -c $<
 
 # -----------------------------------------------------
 

--- a/build/Makefile.SMALL
+++ b/build/Makefile.SMALL
@@ -17,7 +17,7 @@ IDENT='-DID="Rev 2.1"' -DSUN3 -DCARRERA
 # Now this is in bootrom.lds
 #RELOC=0FEF0000
 
-# -Os requries memcpy
+# -Os requries memcpy (now supplied), smallest (~51 KiB)
 # -O3 produces a binary > 64 KiB
 # -O2 works but is quite close to 64 KiB
 # -O1 works and has some margin (~54 KiB)
@@ -64,6 +64,9 @@ KB_OBJS = getkey.o ktab.s2.o
 # These are the scsi drivers
 # see boot.c for the only lines that include them.
 SCSI_OBJS = sc.o sd.o st.o si.o
+
+# memcpy
+MEMCPY_OBJS = memcpy.o
 
 #OBJS = $(BASE_OBJS) $(FB_OBJS)
 OBJS = $(BASE_OBJS)
@@ -237,6 +240,9 @@ si.o: ../dev/si.c
 	$(CC) -c $<
 
 rop.o: ../sys/rop.s
+	$(AS) -c $<
+
+memcpy.o: ../sys/memcpy.S
 	$(AS) -c $<
 
 

--- a/sys/m68kasm.h
+++ b/sys/m68kasm.h
@@ -1,0 +1,40 @@
+/* These are predefined by new versions of GNU cpp.  */
+
+#ifndef __USER_LABEL_PREFIX__
+#define __USER_LABEL_PREFIX__ _
+#endif
+
+#ifndef __REGISTER_PREFIX__
+#define __REGISTER_PREFIX__
+#endif
+
+/* ANSI concatenation macros.  */
+
+#define CONCAT1(a, b) CONCAT2(a, b)
+#define CONCAT2(a, b) a ## b
+
+/* Use the right prefix for global labels.  */
+
+#define SYM(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+
+/* Use the right prefix for registers.  */
+
+#define REG(x) CONCAT1 (__REGISTER_PREFIX__, x)
+
+#define d0 REG (d0)
+#define d1 REG (d1)
+#define d2 REG (d2)
+#define d3 REG (d3)
+#define d4 REG (d4)
+#define d5 REG (d5)
+#define d6 REG (d6)
+#define d7 REG (d7)
+#define a0 REG (a0)
+#define a1 REG (a1)
+#define a2 REG (a2)
+#define a3 REG (a3)
+#define a4 REG (a4)
+#define a5 REG (a5)
+#define a6 REG (a6)
+#define fp REG (fp)
+#define sp REG (sp)

--- a/sys/memcpy.S
+++ b/sys/memcpy.S
@@ -1,0 +1,112 @@
+/* a-memcpy.s -- memcpy, optimised for m68k asm
+ *
+ * Copyright (c) 2007 mocom software GmbH & Co KG)
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions. No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+
+#include "m68kasm.h"
+
+#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+# define MISALIGNED_OK 1
+#else
+# define MISALIGNED_OK 0
+#endif
+	
+	.text
+	.align	4
+
+	.globl	SYM(memcpy)
+	.type	SYM(memcpy), @function
+
+/*   memcpy, optimised
+ *
+ *   strategy:
+ *       - no argument testing (the original memcpy from the GNU lib does
+ *         no checking either)
+ *       - make sure the destination pointer (the write pointer) is long word
+ *         aligned. This is the best you can do, because writing to unaligned
+ *         addresses can be the most costfull thing you could do.
+ *       - Once you have figured that out, we do a little loop unrolling
+ *         to further improve speed.
+ */
+
+SYM(memcpy):
+	move.l	4(sp),a0	| dest ptr
+	move.l	8(sp),a1	| src ptr
+	move.l	12(sp),d1	| len
+	cmp.l	#8,d1		| if fewer than 8 bytes to transfer,
+	blo	.Lresidue	| do not optimise
+
+#if !MISALIGNED_OK
+	/* Goto .Lresidue if either dest or src is not 4-byte aligned */
+	move.l	a0,d0
+	and.l	#3,d0
+	bne	.Lresidue
+	move.l	a1,d0
+	and.l	#3,d0
+	bne	.Lresidue
+#else /* MISALIGNED_OK */
+	/* align dest */
+	move.l	a0,d0		| copy of dest
+	neg.l	d0
+	and.l	#3,d0		| look for the lower two only
+	beq	2f		| is aligned?
+	sub.l	d0,d1
+	lsr.l	#1,d0		| word align needed?
+	bcc	1f
+	move.b	(a1)+,(a0)+
+1:
+	lsr.l	#1,d0		| long align needed?
+	bcc	2f
+	move.w	(a1)+,(a0)+
+2:
+#endif /* !MISALIGNED_OK */
+
+	/* long word transfers */
+	move.l	d1,d0
+	and.l	#3,d1		| byte residue
+	lsr.l	#3,d0
+	bcc	1f		| carry set for 4-byte residue
+	move.l	(a1)+,(a0)+
+1:
+	lsr.l	#1,d0		| number of 16-byte transfers
+	bcc	.Lcopy 		| carry set for 8-byte residue
+	bra	.Lcopy8
+
+1:
+	move.l	(a1)+,(a0)+
+	move.l	(a1)+,(a0)+
+.Lcopy8:
+	move.l	(a1)+,(a0)+
+	move.l	(a1)+,(a0)+
+.Lcopy:
+#if !defined (__mcoldfire__)
+	dbra	d0,1b
+	sub.l	#0x10000,d0
+#else
+	subq.l	#1,d0
+#endif
+	bpl	1b
+	bra	.Lresidue
+
+1:
+	move.b	(a1)+,(a0)+	| move residue bytes
+
+.Lresidue:
+#if !defined (__mcoldfire__)
+	dbra	d1,1b		| loop until done
+#else
+	subq.l	#1,d1
+	bpl	1b
+#endif
+	move.l	4(sp),d0	| return value
+	rts


### PR DESCRIPTION
This is using the same source file from "mocom software GmbH & Co KG" used by e.f. picolib or Retro68.
Using -Os adds several calls to memcpy() and produce the smallest ROM.